### PR TITLE
spec.md: fix 5 small consistency errors (undefined key, typo URN, dup section, field name, media type)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -229,7 +229,7 @@ An agent hosted on Hugging Face Spaces (MCP), published in a manifest:
       "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
       "type": "application/mcp-server+json",
-      "inline": {
+      "data": {
         "name": "Weather Agent",
         "description": "Simple weather lookup using open data",
         "tools": [
@@ -492,7 +492,7 @@ The response returns standard catalog entries with additional relevance scores, 
     {
       "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
-      "type": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://finder.nlweb.ai/search"
     }
   ],
@@ -589,7 +589,7 @@ Deterministic browsing, designed for developer portals. Highly cacheable, relies
 | pageSize | Integer | Max results (default: 20, max: 100). |
 | pageToken | String | Pagination token. |
 
-### 7.3 Protocol Wrappers (Optional)
+### 7.5 Protocol Wrappers (Optional)
 
 While the REST API is mandated as the floor for interoperability, a Registry **MAY** additionally expose its search capability natively via an MCP Tool or an A2A Skill to preserve native orchestrator flows.
 
@@ -634,15 +634,15 @@ This gives the client full control over the federation topology without requirin
   ],
   "referrals": [
     {
-      "identifier": "urn:ai:blweb.ai:registry:public",
+      "identifier": "urn:ai:nlweb.ai:registry:public",
       "displayName": "Public Agent Finder",
-      "type": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://finder.nlweb.ai/search"
     },
     {
       "identifier": "urn:ai:example.com:registry:travel",
       "displayName": "Travel Agent Finder",
-      "mediaType": "application/ai-registry",
+      "type": "application/ai-registry+json",
       "url": "https://travel.finder.example/search"
     }
   ]


### PR DESCRIPTION
Five small consistency fixes in `docs/spec.md`, all verified against the spec's own normative text. No semantic/design changes — examples and headings now match the rules the spec defines.

### Fixes
1. **Undefined `inline` key (§4.4 Solo-Dev MCP example).** §3.4 and the §4.2 field table mandate **exactly one of `url` or `data`**; `inline` is defined nowhere. Changed `"inline"` → `"data"`.
2. **Broken referral URN (§8 Federation example).** `urn:ai:blweb.ai:registry:public` → `urn:ai:nlweb.ai:registry:public`, matching the identical entry in §7.2 and the entry's own `url` (`finder.nlweb.ai`). Also keeps it consistent with the domain-anchored-URN rule in §4.2.1.
3. **Wrong field name in a referral object (§8).** One referral used `"mediaType"` where every other entry uses `"type"`. Changed to `"type"`. (The legitimate `mediaType` fields inside `attestations` per §5.2 are untouched.)
4. **Duplicate section number.** Two `### 7.3` headings — "Protocol Wrappers" appeared as 7.3 *after* "7.4 List". Renumbered to **7.5**.
5. **Media-type string consistency.** Referral examples used `application/ai-registry`; the normative text (§4.1, §7) uses `application/ai-registry+json` — which is what registries match on to discover the search endpoint. Aligned the examples to `+json`.

### Verification
- All 12 JSON code blocks in `spec.md` still parse as valid JSON.
- Confirmed the 5 remaining `mediaType` occurrences are the correct attestation fields (§5.2), not the referral object.

@mindpower — assigning to you for review since you own the recent spec edits. Happy to split into separate commits or drop #5 if you'd rather keep `ai-registry` unsuffixed.
