### PR TITLE
fix: documentation review fixes

### DIFF
--- a/docs/how_to_publish.md
+++ b/docs/how_to_publish.md
@@ -34,7 +34,7 @@ Create a static `ai-catalog.json` manifest listing your agentic resources. Below
 }
 ```
 
-*   **`identifier`**: Naming must follow the domain-anchored URN standard: `urn:ai:<your-domain>:<agent-name>`.
+*   **`identifier`**: Naming must follow the domain-anchored URN standard: `urn:ai:<your-domain>:<namespace>:<agent-name>`.
 *   **`representativeQueries`**: Provide **2–5 natural language queries** to enable high-fidelity semantic vector search.
 
 ---

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,2 @@
 mkdocs-material>=9.5.0
 mkdocs-redirects>=1.2.0
-mkdocs-macros-plugin>=1.0.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
 mkdocs-material>=9.5.0
 mkdocs-redirects>=1.2.0
+mkdocs-macros-plugin>=1.0.0


### PR DESCRIPTION
Fixes the URN format example in the publishing guide to include the `<namespace>` segment, matching the glossary definition and all code examples in the docs (e.g. `urn:ai:acme.com:server:weather`).