### PR TITLE
Add Ora Directory to reference implementations

### DIFF
--- a/docs/ref_implementations.md
+++ b/docs/ref_implementations.md
@@ -69,3 +69,40 @@ curl -sS 'https://ai-catalog.outshift.io/v1/agents?filter=type%3Dapplication%2Fa
 curl -sS 'https://ai-catalog.outshift.io/v1/agents?filter=type%3Dapplication%2Fmcp-server-card%2Bjson' \
 	| jq -r '.results[] | {displayName, identity: .trustManifest.identity, identityType: .trustManifest.identityType, cardUrl: .data.card_data.url} | @json'
 ```
+
+## Ora Directory
+
+The [Ora Directory](https://ora.directory) is an ARD discovery service over products and services that agents use on behalf of users, run by [Ora](https://ora.ai). Ora scans each product for agent-readiness — static checks against its docs, llms.txt, registries, and public APIs, plus live agent runs that attempt to use it end to end — and serves the results over the ARD protocol, alongside the MCP servers, Skills, and OpenAPI specs detected on each product, plus payable x402/MPP HTTP endpoints with per-call pricing, indexed from the public Bazaar registry. Every product entry carries its agent-readiness scorecard as a signed trust attestation, so a client can weigh not only whether a resource matches the task, but whether it has been observed to work for agents.
+
+Ora's publisher manifest at [`ora.ai/.well-known/ai-catalog.json`](https://ora.ai/.well-known/ai-catalog.json) describes Ora's own resources and advertises the registry: its `application/ai-registry+json` entry points at `https://ora.ai/api/ard`, which serves a self-describing descriptor listing the endpoints. The index itself is queried through those endpoints.
+
+### Search and browse
+
+The registry implements the full protocol surface — `POST /search`, `POST /explore`, and `GET /agents` with the spec's `filter` expressions and `orderBy` — and returns `referrals` to peer registries.
+
+```bash
+# Find products for a task
+curl -sS -X POST https://ora.ai/api/ard/search \
+  -H 'content-type: application/json' \
+  -d '{"query":{"text":"send transactional email"},"pageSize":5}' \
+  | jq -r '.results[] | "\(.displayName)\t\(.url)"'
+
+# Browse just the MCP servers in the index
+curl -sS -G https://ora.ai/api/ard/agents \
+  --data-urlencode "filter=type = 'application/mcp-server-card+json'" \
+  --data-urlencode "pageSize=5" \
+  | jq -r '.items[].displayName'
+```
+
+### Verify a scorecard
+
+Each result's `trustManifest.attestations[]` references the product's agent-readiness scorecard, signed as a detached Ed25519 JWS and verifiable against the JWKS at [`ora.ai/.well-known/jwks.json`](https://ora.ai/.well-known/jwks.json):
+
+```bash
+curl -sS https://ora.ai/api/ard/attestation/resend.com \
+  | jq '{subject, score, grade, issuer}'
+```
+
+### MCP
+
+Ora is also reachable as an MCP server at `https://ora.ai/api/mcp` (streamable HTTP); its `discover_products`, `get_score`, and `search_capabilities` tools query the same index.


### PR DESCRIPTION
Adds the [Ora Directory](https://ora.directory) to `docs/ref_implementations.md`.

Ora scans products for agent-readiness (static checks plus live agent runs) and serves the results over ARD. It implements the publisher, discovery-service, and attestor roles, and also acts as a consumer (its scanner reads a scanned domain's `ai-catalog.json`):

- **Catalog**: `https://ora.ai/.well-known/ai-catalog.json`, advertised via `robots.txt` `Agentmap:` and `Link rel="ai-catalog"`; a self-describing `application/ai-registry+json` descriptor is served at the registry base `https://ora.ai/api/ard`.
- **Registry**: `POST /search`, `POST /explore`, and `GET /agents` with the spec's `filter` expressions and `orderBy`, plus `referrals` to peer registries. The index covers scored products, the MCP servers / Skills / OpenAPI specs detected on them, and payable x402/MPP HTTP endpoints.
- **Attestations**: each product entry's `trustManifest.attestations[]` references an agent-readiness scorecard, signed as a detached Ed25519 JWS and verifiable against the JWKS at `/.well-known/jwks.json`.

The section follows the existing page structure (short description plus copy-pasteable examples). All commands were run against the live service before committing; the manifest validates against the authoritative `ai-catalog.schema.json` and the registry endpoints against `ard.openapi.yaml` from `ards-project/ard-spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)