### PR TITLE
Publish the ARD base context at /context/v1

### DIFF
--- a/hooks/context_from_canonical.py
+++ b/hooks/context_from_canonical.py
@@ -1,0 +1,72 @@
+"""MkDocs build hook: publish the ARD base context at /context/v1.
+
+§4.1 of the specification says term IRIs come from a base context served at
+`https://agenticresourcediscovery.org/context/v1`, and that a conformant consumer applies it as
+the JSON-LD `expandContext`. That URL has to resolve, or the one normative reference an entry
+makes to this site is a 404.
+
+The context lives only in ards-project/ard-spec (spec/schemas/ard.context.jsonld), the same way
+the specification text does. This hook fetches it at build time and publishes it verbatim, so the
+site never holds a second copy that can drift from the canonical one.
+
+Two paths are published for the same bytes:
+
+    /context/v1        the URL the specification names
+    /context/v1.jsonld the same document with a `.jsonld` extension
+
+The alias exists because of how static hosting assigns Content-Type. GitHub Pages derives it from
+the file extension and offers no way to set headers, so the extensionless path is served as
+`application/octet-stream`. The JSON-LD 1.1 API requires a remote context to arrive as
+`application/ld+json`, `application/json`, or a `+json` media type, and a strict processor rejects
+anything else — so `/context/v1` resolves and reads correctly, but a strict consumer that
+dereferences it may still refuse it. The `.jsonld` alias gives those consumers a URL that works
+today; making the bare path correct needs either a host that can set headers, or a spec that names
+the suffixed URL. Both are decisions for the spec, not for this build.
+
+Unlike the specification hook, a fetch failure here publishes NOTHING. A placeholder page is a
+reasonable fallback for prose a human is reading; an unparseable or partial document served at a
+context URL is worse than a 404, because a consumer would apply it and expand every term wrongly.
+"""
+import json
+import urllib.error
+import urllib.request
+
+from mkdocs.structure.files import File
+
+SRC = ("https://raw.githubusercontent.com/ards-project/ard-spec/main/"
+       "spec/schemas/ard.context.jsonld")
+DEST = "context/v1"
+DEST_SUFFIXED = "context/v1.jsonld"
+TIMEOUT = 20
+
+
+def _fetch() -> str | None:
+    """The canonical context, or None if it cannot be had intact.
+
+    The document is parsed before being published: a truncated or HTML error body that happened to
+    arrive with a 200 would otherwise be served as the context.
+    """
+    try:
+        with urllib.request.urlopen(SRC, timeout=TIMEOUT) as r:
+            raw = r.read().decode("utf-8")
+    except (urllib.error.URLError, OSError, UnicodeDecodeError):
+        return None
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(doc, dict) or "@context" not in doc:
+        return None
+    return raw
+
+
+def on_files(files, config):
+    raw = _fetch()
+    if raw is None:
+        # Leave the URL 404ing rather than publish something a consumer would trust.
+        print("WARNING - context_from_canonical: could not fetch the ARD base context from "
+              f"{SRC}; /context/v1 will not be published for this build.")
+        return files
+    for dest in (DEST, DEST_SUFFIXED):
+        files.append(File.generated(config, dest, content=raw))
+    return files

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ extra_css:
 # committed docs/spec.md if the repo isn't reachable.
 hooks:
   - hooks/spec_from_canonical.py
+  - hooks/context_from_canonical.py
 
 # Plugins
 # Empty list (not omitted) so MkDocs does NOT re-enable its default `search`


### PR DESCRIPTION
## Problem

§4.1 of the spec says term IRIs come from a base context served at `https://agenticresourcediscovery.org/context/v1`, which a conformant consumer applies as the JSON-LD `expandContext`.

That URL currently returns **404** (the docs-site HTML shell). It's the one normative reference an ARD entry makes back to this site, so anyone reviewing a published entry and clicking through hits a dead link.

The context file itself landed in the canonical repo with ards-project/ard-spec#70 — it just isn't served anywhere.

## Approach

Follows the pattern `hooks/spec_from_canonical.py` already establishes: the context lives **only** in `ards-project/ard-spec` (`spec/schemas/ard.context.jsonld`) and is fetched at build time, so this repo never holds a second copy that can drift from canonical.

Verified locally — the published file is byte-identical to canonical, parses, and works as an `expandContext`:

```
byte-identical to canonical: True
terms: 17 | @vocab: https://agenticresourcediscovery.org/ns#

expanded:
  https://agenticresourcediscovery.org/ns#identifier
  https://agenticresourcediscovery.org/ns#displayName
  https://example.org/okf#taxonomy        ← a second namespace still resolves
```

## Two decisions worth reviewing

**1. Content-Type — the bare path may not satisfy strict processors.**

Static hosting assigns `Content-Type` from the file extension, and GitHub Pages offers no way to set headers. An extensionless file is served as `application/octet-stream`, while the [JSON-LD 1.1 API](https://www.w3.org/TR/json-ld11-api/) requires a remote context to arrive as `application/ld+json`, `application/json`, or a `+json` type — a strict processor rejects anything else.

So `/context/v1` resolves and reads correctly, but a strict consumer that *dereferences* it may still refuse it. This PR also publishes `/context/v1.jsonld` with identical bytes, which gives those consumers a URL that works today.

Making the bare path fully correct needs either a host that can set headers, or a spec that names the suffixed URL. Both are spec/infra decisions rather than build ones, so I've left them alone — happy to follow up whichever way you prefer.

**2. A fetch failure publishes nothing.**

`spec_from_canonical.py` falls back to a placeholder page, which is right for prose a human reads. It would be wrong here: a partial or unparseable document served at a context URL is **worse than a 404**, because a consumer would apply it and expand every term incorrectly. On failure this logs a warning and leaves the URL 404ing.

The fetched document is also parsed and checked for `@context` before publishing, so an HTML error body arriving with a `200` can't be served as the context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)