### PR TITLE
Add the governance page

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -14,7 +14,7 @@ ARD is being designed, reviewed, and supported by agent builders at:
 - ServiceNow
 - Snowflake
 
-All of you are building agents, tools, Skills, and more. We encourage you to add support for AI Catalog and ARD — see our [How to publish](how_to_publish.md) guide.
+All of you are building agents, tools, Skills, and more. We encourage you to add ARD support — see our [How to publish](how_to_publish.md) guide.
 
 ![Contributors to the Agentic Resource Discovery (ARD) specification: Cisco, Databricks, GitHub, GoDaddy, Google, Hugging Face, Microsoft, Nvidia, Salesforce, ServiceNow, Snowflake](assets/logo-wall.png){ .logo-wall }
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -44,10 +44,9 @@ Anyone can contribute. Contribution is open to all, through issues and pull requ
 
 | Company | Representative |
 | :--- | :--- |
-| Cisco | *to be confirmed* |
 | Google | Todd Segal |
 | Hugging Face | Shaun Smith |
-| Microsoft | *to be confirmed* |
+| Microsoft | Dhruv Chand |
 | Amazon | Jeffrey Damick |
 
 **Maintainers**
@@ -58,7 +57,7 @@ Anyone can contribute. Contribution is open to all, through issues and pull requ
 | Nick Cooper | Member at large |
 | Junjie Bu | Google |
 | Shaun Smith | Hugging Face |
-| *to be confirmed* | Microsoft |
+| Dhruv Chand | Microsoft |
 
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -45,11 +45,10 @@ Anyone can contribute. Contribution is open to all, through issues and pull requ
 | Company | Representative |
 | :--- | :--- |
 | Cisco | *to be confirmed* |
-| Google | *to be confirmed* |
+| Google | Todd Segal |
 | Hugging Face | Shaun Smith |
 | Microsoft | *to be confirmed* |
-| Nvidia | *to be confirmed* |
-| Amazon | *to be confirmed* |
+| Amazon | Jeffrey Damick |
 
 **Maintainers**
 
@@ -65,7 +64,7 @@ Anyone can contribute. Contribution is open to all, through issues and pull requ
 
 ## Still to be decided
 
-The structure above is settled. The following are open and will be resolved as the bodies convene:
+The structure above is settled. The following are open, and will be decided by the Board and the Maintainers once they are seated:
 
 - Term lengths and rotation for both bodies.
 - How members at large are nominated and confirmed.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,77 @@
+# Governance
+
+ARD is governed by a deliberately lightweight structure with four commitments: direction stays with organizations actually shipping ARD, technical control stays with people chosen for expertise, no single company can capture the specification, and participation is never bought.
+
+Two bodies share the work. The **Oversight Board** decides *what* ARD should become. The **Maintainers** decide *how*, and own the technical calls. Both operate by consensus where possible.
+
+---
+
+## Oversight Board
+
+**Mandate.** Sets overall direction, scope, and priorities, and approves new major versions.
+
+**Composition.** Five to seven members, **at most one per company**. Each member is nominated by their company. Spots are held for key adoption-driving platform companies and for independent individuals.
+
+**Eligibility.** A company must have a committed product or offering that implements or supports ARD — demonstrated commitment, not just interest.
+
+**No payments.** A seat is earned through product commitment, not financial contribution. **ARD accepts no money for participation**, and no seat, vote, or influence is available for purchase.
+
+---
+
+## Maintainers
+
+**Mandate.** Owns the specification's day-to-day evolution: reviewing and merging changes, maintaining reference endpoints, and resolving technical questions.
+
+**Composition.** Five to seven members, all selected for technical expertise and demonstrated time commitment — the capacity to review submissions, not only the standing to approve them.
+
+**Independence.** At least two members are **members at large**, not employed by any company holding a board seat. This is what keeps technical control from tracking commercial representation.
+
+**Decisions.** Specification changes are agreed by majority vote of the Maintainers.
+
+---
+
+## How the two relate
+
+The Board sets direction; the Maintainers exercise technical judgment within it. A member of one body may sit on the other only where the independence rule above still holds.
+
+Anyone can contribute. Contribution is open to all, through issues and pull requests in the [specification repository](https://github.com/ards-project/ard-spec) — membership of either body is not a precondition for proposing or shaping a change.
+
+---
+
+## Membership
+
+**Oversight Board**
+
+| Company | Representative |
+| :--- | :--- |
+| Cisco | *to be confirmed* |
+| Google | *to be confirmed* |
+| Hugging Face | Shaun Smith |
+| Microsoft | *to be confirmed* |
+| Nvidia | *to be confirmed* |
+| Amazon | *to be confirmed* |
+
+**Maintainers**
+
+| Member | Affiliation |
+| :--- | :--- |
+| R.V. Guha (Chair) | Member at large |
+| Nick Cooper | Member at large |
+| Junjie Bu | Google |
+| Shaun Smith | Hugging Face |
+| *to be confirmed* | Microsoft |
+
+---
+
+## Still to be decided
+
+The structure above is settled. The following are open and will be resolved as the bodies convene:
+
+- Term lengths and rotation for both bodies.
+- How members at large are nominated and confirmed.
+- Quorum, and tie-breaking or fallback voting when consensus fails.
+- The process by which a company joins the Board after the initial cohort.
+
+## Neutral host
+
+Whether to sit ARD under a neutral host — W3C, an AI foundation, or similar — is a decision for **roughly twelve months out**, not now. The structure above stands on its own in the interim.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -10,7 +10,7 @@ Two bodies share the work. The **Oversight Board** decides *what* ARD should bec
 
 **Mandate.** Sets overall direction, scope, and priorities, and approves new major versions.
 
-**Composition.** Five to seven members, **at most one per company**. Each member is nominated by their company. Spots are held for key adoption-driving platform companies and for independent individuals.
+**Composition.** Four to seven members, **at most one per company**. Each member is nominated by their company. Spots are held for key adoption-driving platform companies and for independent individuals.
 
 **Eligibility.** A company must have a committed product or offering that implements or supports ARD — demonstrated commitment, not just interest.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
     - How ARD works: how_ard_works.md
     - Interoperability: interoperability.md
     - Contributors: contributors.md
+    - Governance: governance.md
     - FAQ: faq.md
     - Glossary: glossary.md
   - Guides:


### PR DESCRIPTION
Publishes the approved governance structure at `/governance/`, linked under **About**.

- **Oversight Board** — direction, scope, priorities, approves major versions. At most one seat per company, nominated by their company.
- **Maintainers** — day-to-day evolution of the spec, by majority vote. Selected for technical expertise and review capacity.
- **Eligibility** — a company must have a committed product or offering implementing or supporting ARD.
- **No payments** — a seat is earned through product commitment; ARD accepts no money for participation.
- **Independence** — at least two Maintainers are not employed by any company holding a board seat.
- Contribution is open to anyone, regardless of membership of either body.

**Board:** Todd Segal (Google), Shaun Smith (Hugging Face), Dhruv Chand (Microsoft), Jeffrey Damick (Amazon).
**Maintainers:** R.V. Guha (Chair, member at large), Nick Cooper (member at large), Junjie Bu (Google), Shaun Smith (Hugging Face), Dhruv Chand (Microsoft).

Email addresses are deliberately omitted from the page.

Also drops a stale "AI Catalog and ARD" phrasing from `contributors.md`.

`mkdocs build --strict` passes.

Term lengths and rotation, member-at-large nomination, quorum and tie-breaking, and the process for a company joining the Board after the initial cohort are published as open, to be decided by the Board and Maintainers once seated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)